### PR TITLE
Minimum ssh keysize additional changes

### DIFF
--- a/controller/app/validators/key_content_validator.rb
+++ b/controller/app/validators/key_content_validator.rb
@@ -1,3 +1,4 @@
+require 'net/ssh'
 class KeyContentValidator < ActiveModel::Validator
    def validate(record)
      # If it is not a key type that we have a size requirement for or 

--- a/controller/openshift-origin-controller.gemspec
+++ b/controller/openshift-origin-controller.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "openshift-origin-common"
   s.add_dependency('state_machine')
   s.add_dependency('dnsruby')
+  s.add_dependency('net-ssh')
   s.add_dependency('httpclient')
   s.add_dependency 'mongoid', '>= 3.0.17'
   s.add_development_dependency('rake', '>= 0.8.7', '<= 0.9.6')  

--- a/controller/test/cucumber/rest-keys.feature
+++ b/controller/test/cucumber/rest-keys.feature
@@ -8,21 +8,21 @@ Feature: keys
   Scenario Outline: Create, List, Get, Update, Delete
     Given a new user
     And I accept "<format>"
-    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=XYZ123567"
+    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
     Then the response should be "201"
-    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=XYZ123567"
+    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
     When I send a GET request to "/user/keys"
     Then the response should be "200"
     When I send a GET request to "/user/keys/api"
     Then the response should be "200"
-    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=XYZ123567"
-    When I send a PUT request to "/user/keys/api" with the following:"type=ssh-rsa&content=ABC890"
+    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
+    When I send a PUT request to "/user/keys/api" with the following:"type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQCyCOjIXYAZjJ6nrzM9fUkY/pgYMI/N3N+1Cw9srzlPpJgclJmqga8lCz/LtmtM4GIXQUbqgan3DgVL8bxgFZPF7nOS4RRfu9Ggv5ZTIQ595q/pnxS2ShMpl8BFhO/mpqfCyOi1yf6/HtjLTLO9Jju/4lq4baCKjufd8ZnIWC0U+DK7/dBYcrKUpQFzl6isply1lg/rUhCGdXbqJlajIxwoY1qZP7KBc3WuoMPO7rVEblKqAfhMStuy2nIPzBhYQU43Y2UQ4THxUjgbAUizaWavqijkks7xZXREmsfoKURO4hHfg43gjL0jmBU7PSqVq8yzCR3OsW0YBKlnoNy5K/Yr"
     Then the response should be "200"
-    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=ABC890"
+    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQCyCOjIXYAZjJ6nrzM9fUkY/pgYMI/N3N+1Cw9srzlPpJgclJmqga8lCz/LtmtM4GIXQUbqgan3DgVL8bxgFZPF7nOS4RRfu9Ggv5ZTIQ595q/pnxS2ShMpl8BFhO/mpqfCyOi1yf6/HtjLTLO9Jju/4lq4baCKjufd8ZnIWC0U+DK7/dBYcrKUpQFzl6isply1lg/rUhCGdXbqJlajIxwoY1qZP7KBc3WuoMPO7rVEblKqAfhMStuy2nIPzBhYQU43Y2UQ4THxUjgbAUizaWavqijkks7xZXREmsfoKURO4hHfg43gjL0jmBU7PSqVq8yzCR3OsW0YBKlnoNy5K/Yr"
     When I send a GET request to "/user/keys/blah"
     Then the response should be "404"
     And the error message should have "severity=error&exit_code=118"
-    When I send a PUT request to "/user/keys/blah" with the following:"type=ssh-rsa&content=ABC890"
+    When I send a PUT request to "/user/keys/blah" with the following:"type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQCyCOjIXYAZjJ6nrzM9fUkY/pgYMI/N3N+1Cw9srzlPpJgclJmqga8lCz/LtmtM4GIXQUbqgan3DgVL8bxgFZPF7nOS4RRfu9Ggv5ZTIQ595q/pnxS2ShMpl8BFhO/mpqfCyOi1yf6/HtjLTLO9Jju/4lq4baCKjufd8ZnIWC0U+DK7/dBYcrKUpQFzl6isply1lg/rUhCGdXbqJlajIxwoY1qZP7KBc3WuoMPO7rVEblKqAfhMStuy2nIPzBhYQU43Y2UQ4THxUjgbAUizaWavqijkks7xZXREmsfoKURO4hHfg43gjL0jmBU7PSqVq8yzCR3OsW0YBKlnoNy5K/Yr"
     Then the response should be "404"
     And the error message should have "severity=error&exit_code=118"
     When I send a DELETE request to "/user/keys/api"
@@ -35,7 +35,6 @@ Feature: keys
      | format |
      | JSON   |
      | XML    |
-
 
   Scenario Outline: Create key with with blank, missing and invalid content
     Given a new user
@@ -58,16 +57,16 @@ Feature: keys
   Scenario Outline: Create key with with blank, missing, too long and invalid name
     Given a new user
     And I accept "<format>"
-    When I send a POST request to "/user/keys" with the following:"name=cucum?*ber&type=ssh-rsa&content=XYZ123"
+    When I send a POST request to "/user/keys" with the following:"name=cucum?*ber&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
     Then the response should be "422"
     And the error message should have "field=name&severity=error&exit_code=117"
-    When I send a POST request to "/user/keys" with the following:"name=&type=ssh-rsa&content=XYZ123"
+    When I send a POST request to "/user/keys" with the following:"name=&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
     Then the response should be "422"
     And the error message should have "field=name&severity=error&exit_code=117"
-    When I send a POST request to "/user/keys" with the following:"type=ssh-rsa&content=XYZ123"
+    When I send a POST request to "/user/keys" with the following:"type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
     Then the response should be "422"
     And the error message should have "field=name&severity=error&exit_code=117"
-    When I send a POST request to "/user/keys" with the following:"name=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc&type=ssh-rsa&content=XYZ123"
+    When I send a POST request to "/user/keys" with the following:"name=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
     Then the response should be "422"
     And the error message should have "field=name&severity=error&exit_code=117"
 
@@ -97,7 +96,7 @@ Feature: keys
   Scenario Outline: Update key with with blank, missing and invalid content
     Given a new user
     And I accept "<format>"
-    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=XYZ123"
+    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
     Then the response should be "201"
     When I send a PUT request to "/user/keys/api" with the following:"type=ssh-rsa&content="
     Then the response should be "422"
@@ -110,7 +109,7 @@ Feature: keys
     And the error message should have "field=content&severity=error&exit_code=108"
     When I send a GET request to "/user/keys/api"
     Then the response should be "200"
-    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=XYZ123"
+    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
 
     Scenarios:
      | format |
@@ -120,7 +119,7 @@ Feature: keys
   Scenario Outline: Update key with blank, missing and invalid type
     Given a new user
     And I accept "<format>"
-    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=XYZ123"
+    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
     Then the response should be "201"
     When I send a PUT request to "/user/keys/api" with the following:"type=&content=ABC890"
     Then the response should be "422"
@@ -133,7 +132,7 @@ Feature: keys
     And the error message should have "field=type&severity=error&exit_code=116"
     When I send a GET request to "/user/keys/api"
     Then the response should be "200"
-    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=XYZ123"
+    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
 
     Scenarios:
      | format |
@@ -143,14 +142,34 @@ Feature: keys
   Scenario Outline: Create duplicate key
     Given a new user
     And I accept "<format>"
-    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=XYZ123"
+    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
     Then the response should be "201"
-    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=XYZ1234"
+    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAAAgQCwSyig/Pr/S/+OHgnl4LjgckwnUTi48yAz/zmugNxyBVs1CUNXaP8tQ0njqgjqjZDFbdkvGbsTDhJfWqOkQ5vD66jgkpojHmEsRX+KtsrKl2vDrRCXzPvxQ1tfE9wxrcWatQqUpESK0ZBg7C3ssg+Djk44OeDPWYyMh2hv6jBVvQ=="
     Then the response should be "409"
-    When I send a POST request to "/user/keys" with the following:"name=apiX&type=ssh-rsa&content=XYZ123"
+    When I send a POST request to "/user/keys" with the following:"name=apiX&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
     Then the response should be "409"
 
     Scenarios:
      | format |
      | JSON   |
      | XML    |
+
+   Scenario Outline: Create a keys of varying lengths
+    Given a new user
+    And I accept "<format>"
+    When I send a POST request to "/user/keys" with the following:"name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
+    Then the response should be "201"
+    And the response should be a "key" with attributes "name=api&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAABAQDa/hAlFXyOr+8NIroKEJjqLkxOJD0qZLGXiMjIj4KulKt6H81OGZbnQP+sBfZtQ0aZA5IhQf5paznU8rSPz1yRcXUZv40mi/6yzpnI8pM2IJ7AHRrrXN/LfCrHInCfhJKzjh8aZwsaB/367diCfTundPsHcth2V70v7lTnrR1QJsKsFJFbsgdfiP6fw/+VN9kD37zJZQ9zLG4cy8BBfZKOqTg9wVgGEWOx6KBGDbX1UqnJZ8HFbmTgoUJbyLDSdAjnDGiM1IvyFat5Yw9nhNbT+mc/2e/4VfH0T3G9ff2dbVH37GDNZ5muB8HfzHhq3FT/VMmyfzVhWKxDmXG/E8IX"
+    When I send a POST request to "/user/keys" with the following:"name=too-short&type=ssh-rsa&content=AAAAB3NzaC1yc2EAAAADAQABAAAAYQDZZwwO7HDIfgwyv6FKYMWSg9dLYkhUuZttkiJSUXDtpGhYQ++9YdzEubqdFWnzc5wObrzL9ttiVUuwqpNCSguU8YD3Lts/OsCeS1q/3EPunuVxREa+QxZDnYaEg5/zp8s="
+    Then the response should be "422"
+    And the error message should have "field=content&severity=error&exit_code=108"
+    When I send a POST request to "/user/keys" with the following:"name=dss1024&type=ssh-dss&content=AAAAB3NzaC1kc3MAAACBAMKbO9DyBwLdSUkm/gE0KS8pL0EWSTe0B6IzhghbOA2oQyz/g/2LvehUZfempmcIhEDIVburLlWEKusuk8B/bngcnMWx3HmtIVopbuSbFrZE7PAiE4iRfb5VKiQUpWtGiTGDTMq9JJWg1TA0QU7HdKwRVTWzCcRzjE3b/RvoHWQzAAAAFQCaEQ+SG4xlUs0/KV66se7qZRZKYwAAAIAPhZJ+dtQblwOGk7a4TzcjWZhXjT6Sa2vFgXFnbjjVOTUvog8SIGkrWxtgNeF6YgrgZYHhSJEariLdh7ZiQyKA4+9J0h1NYdmfrNCM+6ZohP2uMum7I7JTowjiET0iZrli1JciwyO8hz+YMLrgeO9AfOnXQwMUwiDcZ44dfIxlLQAAAIEAugXzYScsDJs1S9OFVQvY0OiLcQE/sBoDuud1LxDrdN9Ui45j1USOgxZTUMRWnBlH38Vy7cPOrPBSUM7WvjUnlei1767IRTDld4wNstICtzbUsRX7TvpKv6uyO4NzCYv2EH4ap74kpHxKh6t7pXsRo3B90Aex8NGwDAHO6iEq49Y="
+    Then the response should be "201"
+    And the response should be a "key" with attributes "name=dss1024&type=ssh-dss&content=AAAAB3NzaC1kc3MAAACBAMKbO9DyBwLdSUkm/gE0KS8pL0EWSTe0B6IzhghbOA2oQyz/g/2LvehUZfempmcIhEDIVburLlWEKusuk8B/bngcnMWx3HmtIVopbuSbFrZE7PAiE4iRfb5VKiQUpWtGiTGDTMq9JJWg1TA0QU7HdKwRVTWzCcRzjE3b/RvoHWQzAAAAFQCaEQ+SG4xlUs0/KV66se7qZRZKYwAAAIAPhZJ+dtQblwOGk7a4TzcjWZhXjT6Sa2vFgXFnbjjVOTUvog8SIGkrWxtgNeF6YgrgZYHhSJEariLdh7ZiQyKA4+9J0h1NYdmfrNCM+6ZohP2uMum7I7JTowjiET0iZrli1JciwyO8hz+YMLrgeO9AfOnXQwMUwiDcZ44dfIxlLQAAAIEAugXzYScsDJs1S9OFVQvY0OiLcQE/sBoDuud1LxDrdN9Ui45j1USOgxZTUMRWnBlH38Vy7cPOrPBSUM7WvjUnlei1767IRTDld4wNstICtzbUsRX7TvpKv6uyO4NzCYv2EH4ap74kpHxKh6t7pXsRo3B90Aex8NGwDAHO6iEq49Y="
+
+    Scenarios:
+     | format |
+     | JSON   |
+     | XML    |
+
+


### PR DESCRIPTION
I had to make these additional changes to get things working. I'm not a rails or even ruby guy so I'm a bit unsure of the right way to ensure the proper gems are imported but this seems to work.

The changes to the tests are all to accommodate enforcing `MINIMUM_SSH_KEYSIZE='ssh-rsa|1024, ssh-dss|1024'` which we should add to https://github.com/openshift/li/pull/2976 in rhc-server-common/etc/openshift/broker-dev.conf along with the comments explaining what the purpose is. This is the file that's used when running tests.
